### PR TITLE
Add minimal React/Next.js example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ Get help: [Post in our discussion board](https://github.com/orgs/skills/discussi
 &copy; 2023 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 
 </footer>
+
+## Next.js example app
+
+A minimal React/Next.js example is included in [`nextjs-example`](./nextjs-example).

--- a/nextjs-example/.eslintrc.json
+++ b/nextjs-example/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/nextjs-example/README.md
+++ b/nextjs-example/README.md
@@ -1,0 +1,13 @@
+# Next.js Example App
+
+This folder contains a minimal React/Next.js app you can use as an example.
+
+## Run locally
+
+```bash
+cd nextjs-example
+npm install
+npm run dev
+```
+
+Open http://localhost:3000 in your browser.

--- a/nextjs-example/app/globals.css
+++ b/nextjs-example/app/globals.css
@@ -1,0 +1,49 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: linear-gradient(180deg, #f8fafc 0%, #eff6ff 100%);
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  color: #0f172a;
+}
+
+h1 {
+  margin-bottom: 0.5rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+h2 {
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+}
+
+p {
+  line-height: 1.6;
+}
+
+ul {
+  padding-left: 1.2rem;
+  line-height: 1.8;
+}
+
+pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 10px;
+  padding: 1rem;
+  overflow-x: auto;
+}

--- a/nextjs-example/app/layout.js
+++ b/nextjs-example/app/layout.js
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Next.js Example App',
+  description: 'A simple React/Next.js example app.',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/nextjs-example/app/page.js
+++ b/nextjs-example/app/page.js
@@ -1,0 +1,34 @@
+const features = [
+  'File-based routing with the App Router',
+  'Reusable React components',
+  'Fast refresh in development mode',
+];
+
+export default function HomePage() {
+  return (
+    <main className="container">
+      <h1>React + Next.js Example</h1>
+      <p>
+        This example app gives you a quick starting point you can run and modify.
+      </p>
+
+      <section>
+        <h2>What this demonstrates</h2>
+        <ul>
+          {features.map((feature) => (
+            <li key={feature}>{feature}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2>Run it locally</h2>
+        <pre>
+{`cd nextjs-example
+npm install
+npm run dev`}
+        </pre>
+      </section>
+    </main>
+  );
+}

--- a/nextjs-example/jsconfig.json
+++ b/nextjs-example/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/nextjs-example/next.config.mjs
+++ b/nextjs-example/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/nextjs-example/package.json
+++ b/nextjs-example/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nextjs-example",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.32",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "eslint": "8.57.1",
+    "eslint-config-next": "14.2.32"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, runnable React/Next.js starter that demonstrates the App Router and basic project configuration so users have a reference example in the repo.

### Description
- Added a new `nextjs-example` folder containing a minimal Next.js App Router project with `app/layout.js`, `app/page.js`, and `app/globals.css` for a simple UI.
- Added project configuration files: `package.json`, `next.config.mjs`, `jsconfig.json`, and `.eslintrc.json` to make the example ready-to-install and lintable.
- Included a local `nextjs-example/README.md` with run instructions and updated the repository `README.md` to link to the example folder.
- Changes were staged and committed to the repository as part of this update.

### Testing
- Ran `npm install` in `nextjs-example` which failed with a `403 Forbidden` error from `https://registry.npmjs.org` so dependencies were not installed (failed).
- Ran `npm run build` in `nextjs-example` which failed because `next` was not available due to the missing dependencies (`next: not found`) (failed).
- Attempted an automated Playwright page check to capture a screenshot of `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because the app was not running after the install failure (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf918a0c4832d976c593ee7415b33)